### PR TITLE
net/sched: move police action structures to header

### DIFF
--- a/include/net/tc_act/tc_police.h
+++ b/include/net/tc_act/tc_police.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __NET_TC_POLICE_H
+#define __NET_TC_POLICE_H
+
+#include <net/act_api.h>
+
+struct tcf_police {
+	struct tc_action        common;
+	int                     tcfp_result;
+	u32                     tcfp_ewma_rate;
+	s64                     tcfp_burst;
+	u32                     tcfp_mtu;
+	s64                     tcfp_toks;
+	s64                     tcfp_ptoks;
+	s64                     tcfp_mtu_ptoks;
+	s64                     tcfp_t_c;
+	struct psched_ratecfg   rate;
+	bool                    rate_present;
+	struct psched_ratecfg   peak;
+	bool                    peak_present;
+};
+
+#define to_police(pc) ((struct tcf_police *)pc)
+
+/* old policer structure from before tc actions */
+struct tc_police_compat {
+	u32                     index;
+	int                     action;
+	u32                     limit;
+	u32                     burst;
+	u32                     mtu;
+	struct tc_ratespec      rate;
+	struct tc_ratespec      peakrate;
+};
+
+static inline bool is_tcf_police(const struct tc_action *act)
+{
+#ifdef CONFIG_NET_CLS_ACT
+	if (act->ops && act->ops->type == TCA_ID_POLICE)
+		return true;
+#endif
+	return false;
+}
+
+static inline u64 tcf_police_rate_bytes_ps(const struct tc_action *act)
+{
+	struct tcf_police *police = to_police(act);
+
+	return police->rate.rate_bytes_ps;
+}
+
+static inline s64 tcf_police_tcfp_burst(const struct tc_action *act)
+{
+	struct tcf_police *police = to_police(act);
+
+	return police->tcfp_burst;
+}
+
+#endif /* __NET_TC_POLICE_H */

--- a/net/sched/act_police.c
+++ b/net/sched/act_police.c
@@ -21,35 +21,7 @@
 #include <linux/slab.h>
 #include <net/act_api.h>
 #include <net/netlink.h>
-
-struct tcf_police {
-	struct tc_action	common;
-	int			tcfp_result;
-	u32			tcfp_ewma_rate;
-	s64			tcfp_burst;
-	u32			tcfp_mtu;
-	s64			tcfp_toks;
-	s64			tcfp_ptoks;
-	s64			tcfp_mtu_ptoks;
-	s64			tcfp_t_c;
-	struct psched_ratecfg	rate;
-	bool			rate_present;
-	struct psched_ratecfg	peak;
-	bool			peak_present;
-};
-
-#define to_police(pc) ((struct tcf_police *)pc)
-
-/* old policer structure from before tc actions */
-struct tc_police_compat {
-	u32			index;
-	int			action;
-	u32			limit;
-	u32			burst;
-	u32			mtu;
-	struct tc_ratespec	rate;
-	struct tc_ratespec	peakrate;
-};
+#include <net/tc_act/tc_police.h>
 
 /* Each policer is serialized by its individual spinlock */
 


### PR DESCRIPTION
Move tcf_police and tc_police_compat structures to a header. Making them
usable to other code for example drivers that would offload police actions
to hardware.

Signed-off-by: Gavin Li <gavinl@nvidia.com>