### PR TITLE
net/sched: Delayed deletion of TC actions

### DIFF
--- a/include/net/act_api.h
+++ b/include/net/act_api.h
@@ -28,6 +28,7 @@ struct tc_action {
 	u32				tcfa_index;
 	refcount_t			tcfa_refcnt;
 	atomic_t			tcfa_bindcnt;
+	atomic_t			delayed_delete;
 	int				tcfa_action;
 	struct tcf_t			tcfa_tm;
 	struct gnet_stats_basic_packed	tcfa_bstats;
@@ -99,6 +100,7 @@ struct tc_action_ops {
 	size_t  (*get_fill_size)(const struct tc_action *act);
 	struct net_device *(*get_dev)(const struct tc_action *a);
 	void	(*put_dev)(struct net_device *dev);
+	void	(*set_delayed_delete)(struct tc_action *);
 };
 
 struct tc_action_net {

--- a/net/sched/act_police.c
+++ b/net/sched/act_police.c
@@ -292,6 +292,11 @@ static int tcf_police_search(struct net *net, struct tc_action **a, u32 index,
 	return tcf_idr_search(tn, a, index);
 }
 
+static void tcf_police_set_delayed_delete(struct tc_action *a)
+{
+	atomic_inc(&a->delayed_delete);
+}
+
 MODULE_AUTHOR("Alexey Kuznetsov");
 MODULE_DESCRIPTION("Policing actions");
 MODULE_LICENSE("GPL");
@@ -306,6 +311,7 @@ static struct tc_action_ops act_police_ops = {
 	.walk		=	tcf_police_walker,
 	.lookup		=	tcf_police_search,
 	.size		=	sizeof(struct tcf_police),
+	.set_delayed_delete =	tcf_police_set_delayed_delete,
 };
 
 static __net_init int police_init_net(struct net *net)


### PR DESCRIPTION
Add a flag to TC action ops structure and set it when there is a
deletion request received but it is still referenced by other actions,
eg, a police action still referenced by TC flowers.

The TC action with the flag set will be automatically freed once the
last action referencing it is removed.

Signed-off-by: Gavin Li <gavinl@nvidia.com>